### PR TITLE
Fix import map mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
           "imports": {
             "react/": "https://esm.sh/react@^19.1.0/",
             "react": "https://esm.sh/react@^19.1.0",
-            "react-router-dom": "https://esm.sh/react-router-dom@5.3.4",
+            "react-router-dom": "https://esm.sh/react-router-dom@^6.30.1",
             "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
             "lucide-react": "https://esm.sh/lucide-react@^0.513.0",
             "framer-motion": "https://esm.sh/framer-motion@^12.16.0",


### PR DESCRIPTION
## Summary
- use React Router v6 in the import map

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849886b3fe48323822b6279e9765d0f