### PR TITLE
Fix unused lucide-react import in CourseCard

### DIFF
--- a/components/CourseCard.tsx
+++ b/components/CourseCard.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Course } from '../types';
-import { ExternalLink, Info } from 'lucide-react'; // Changed ChevronLeft to Info for better context if needed
+import { Info } from 'lucide-react'; // Using the Info icon to indicate more details
 import { motion } from 'framer-motion';
 import Button from './ui/Button'; // Assuming Button component is appropriately set up for this usage
 


### PR DESCRIPTION
## Summary
- remove the unused `ExternalLink` import from `CourseCard`
- update the icon comment accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68498a2f70ec83238eb2d5d753da48a5