### PR TITLE
Fix KaTeX SRI and chat widget visibility

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -135,16 +135,6 @@ useEffect(() => {
 
   return (
     <div className="fixed bottom-4 right-4 z-50 text-right relative" dir="rtl">
-      <motion.button
-        whileHover={{ scale: 1.1, rotate: 5 }}
-        whileTap={{ scale: 0.95 }}
-        onClick={() => setOpen(o => !o)}
-        className="bg-gradient-to-br from-primary to-primary-dark text-white rounded-full p-3 shadow-xl focus:outline-none flex items-center"
-      >
-        <span className="ml-2">צ'אט</span>
-        <MessageSquare size={24} />
-      </motion.button>
-
       <AnimatePresence>
         {open && (
           <motion.div
@@ -210,15 +200,17 @@ useEffect(() => {
           </motion.div>
         )}
       </AnimatePresence>
-      <motion.button
-        whileHover={{ scale: 1.1, rotate: 5 }}
-        whileTap={{ scale: 0.95 }}
-        onClick={() => setOpen(o => !o)}
-        className="bg-gradient-to-br from-primary to-primary-dark text-white rounded-full p-3 shadow-xl focus:outline-none flex items-center"
-      >
-        <span className="ml-2">צ'אט</span>
-        <MessageSquare size={24} />
-      </motion.button>
+      {!open && (
+        <motion.button
+          whileHover={{ scale: 1.1, rotate: 5 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => setOpen(true)}
+          className="bg-gradient-to-br from-primary to-primary-dark text-white rounded-full p-3 shadow-xl focus:outline-none flex items-center"
+        >
+          <span className="ml-2">צ'אט</span>
+          <MessageSquare size={24} />
+        </motion.button>
+      )}
     </div>
   );
 };

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-KMGtAWxiZ1xO6PvxI6Bjq5lHppZArYrusS4X+h0/pYfZfbQfVIAtF5LuPp6BXPDh" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww" crossorigin="anonymous">
 
     <style>
         body {
@@ -33,7 +33,7 @@
         ::-webkit-scrollbar-thumb {
             background-color: #94a3b8; /* Tailwind slate-400 */
             border-radius: 10px;
-            border: 3px solid #f1f5f9; /* Tailwind slate-100 */
+            border: 3px solid transparent;
         }
 
             ::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
## Summary
- fix integrity hash for KaTeX stylesheet
- hide scrollbar thumb border in dark mode
- remove duplicate chat button and show button only when chat is closed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849a1e5db748323b193209edfb04c04