### PR TITLE
Fix: Update KaTeX integrity, scrollbar style, and chat button position

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -142,7 +142,7 @@ useEffect(() => {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 40, scale: 0.9 }}
             transition={{ type: 'spring', stiffness: 250, damping: 25 }}
-            className="w-96 h-[550px] bg-white dark:bg-slate-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col mb-3"
+            className="w-96 h-[550px] bg-white dark:bg-slate-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col absolute bottom-full right-0 mb-2"
           >
             <div className="flex justify-between items-center p-4 border-b border-gray-200 dark:border-gray-700">
               <h3 className="text-primary dark:text-sky-400 font-semibold text-lg">נציג מכון אביב</h3>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-KMGtAWxiZ1xO6PvxI6Bjq5lHppZArYrusS4X+h0/pYfZfbQfVIAtF5LuPp6BXPDh" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww" crossorigin="anonymous">
 
     <style>
         body {
@@ -46,7 +46,7 @@
 
         html.dark ::-webkit-scrollbar-thumb {
             background-color: #475569; /* Tailwind slate-600 */
-            border-color: #0f172a; /* Tailwind slate-900 */
+            border-color: #475569; /* Tailwind slate-600, same as background-color */
         }
 
             html.dark ::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
This commit addresses three UI issues:

1.  Updates the integrity hash for the KaTeX CSS to the correct value, preventing it from being blocked by the browser.
2.  Adjusts the dark mode scrollbar styling by setting the thumb's border color to match its background. This removes the white edges around the scrollbar thumb in dark mode.
3.  Modifies the ChatWidget component to prevent the chat button from moving when the chat window is opened. The chat window is now positioned absolutely above the button.