### PR TITLE
Fix ChatWidget button import

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useLocation, Link } from 'react-router-dom';
 import { MessageSquare, Send } from 'lucide-react';
-import { Button } from './ui/Button';
+import Button from './ui/Button';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';


### PR DESCRIPTION
## Summary
- fix incorrect named import in ChatWidget

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ab8b4c1c83239adf8a02798f26e6