### PR TITLE
Fix article rendering from Supabase

### DIFF
--- a/components/sections/ArticlesSection.tsx
+++ b/components/sections/ArticlesSection.tsx
@@ -102,14 +102,21 @@ const ArticlesSection: React.FC<ArticlesSectionProps> = ({ maxItems, showTitle =
                 }
 
                 if (supabaseArticles) {
-                    // Type assertion for Supabase articles if necessary, or data transformation
-                    const fetchedArticles: Article[] = supabaseArticles.map(article => ({
-                        ...article,
-                        // Ensure date is a string. Supabase might return it as Date object or ISO string.
-                        date: article.date ? new Date(article.date).toLocaleDateString('he-IL') : 'N/A',
-                        // Ensure id is a string
-                        id: String(article.id)
-                    }));
+                    // Transform Supabase data to match our Article interface
+                    const fetchedArticles: Article[] = supabaseArticles.map((supaArticle: any) => {
+                        const created = supaArticle.date || supaArticle.created_at;
+                        const bodyText: string = supaArticle.fullContent || supaArticle.body || '';
+
+                        return {
+                            ...supaArticle,
+                            fullContent: bodyText,
+                            excerpt: supaArticle.excerpt || bodyText.substring(0, 150),
+                            author: supaArticle.author || 'צוות מכון אביב',
+                            imageUrl: supaArticle.imageUrl,
+                            date: created ? new Date(created).toLocaleDateString('he-IL') : 'N/A',
+                            id: String(supaArticle.id),
+                        } as Article;
+                    });
 
                     // Combine and remove duplicates (preferring Supabase articles if IDs clash)
                     const combinedArticles = [

--- a/pages/AdminPage.tsx
+++ b/pages/AdminPage.tsx
@@ -114,6 +114,7 @@ const AdminPage: React.FC = () => {
       category: currentArticle.category || null,
       artag: currentArticle.artag || null,
       imageUrl: currentArticle.imageUrl || null,
+      date: new Date().toLocaleDateString('he-IL'),
     };
     try {
       const { error } = currentArticle.id ? await supabase.from('articles').update(articleData).eq('id', currentArticle.id) : await supabase.from('articles').insert([articleData]);

--- a/pages/FAQPage.tsx
+++ b/pages/FAQPage.tsx
@@ -32,7 +32,7 @@ const FAQPage: React.FC = () => {
         if (supabaseFaqItems && supabaseFaqItems.length > 0) {
           const supabaseCategories: { [key: string]: FAQCategory } = {};
           const defaultCategoryId = 'supabase_qa';
-          const defaultCategoryTitle = 'שאלות מהמאגר';
+          const defaultCategoryTitle = 'שאלות שאתם שאלתם אותנו';
 
           supabaseFaqItems.forEach(item => {
             // All items from 'qa' table will go into a single default category

--- a/pages/FullArticlePage.tsx
+++ b/pages/FullArticlePage.tsx
@@ -178,8 +178,8 @@ const FullArticlePage: React.FC = () => {
                 const { data, error: supabaseError } = await supabase
                     .from('articles')
                     .select('*')
-                    .eq('artag', articleId) // Use 'artag' for querying
-                    .single(); // Expecting a single article
+                    .eq('artag', articleId)
+                    .single();
 
                 if (supabaseError) {
                     if (supabaseError.code === 'PGRST116') { // PostgREST error for "No rows found"
@@ -188,7 +188,18 @@ const FullArticlePage: React.FC = () => {
                         throw supabaseError;
                     }
                 } else if (data) {
-                    setArticle(data as Article);
+                    const created = (data as any).date || (data as any).created_at;
+                    const bodyText: string = (data as any).fullContent || (data as any).body || '';
+                    const transformed: Article = {
+                        ...(data as any),
+                        fullContent: bodyText,
+                        excerpt: (data as any).excerpt || bodyText.substring(0, 150),
+                        author: (data as any).author || 'צוות מכון אביב',
+                        imageUrl: (data as any).imageUrl,
+                        date: created ? new Date(created).toLocaleDateString('he-IL') : 'N/A',
+                        id: String((data as any).id),
+                    };
+                    setArticle(transformed);
                 } else {
                      setArticle(null); // Article not found
                 }


### PR DESCRIPTION
## Summary
- map Supabase fields to local Article interface
- parse article body when fetching individual article
- store update date when creating/editing articles
- update FAQ label for Supabase questions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849f56409dc8323840eff474d07d2a1