### PR TITLE
Fix auth modal import paths

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,9 +6,9 @@ import DarkModeToggle from './DarkModeToggle';
 import { Menu, X, ExternalLink as ExternalLinkIcon, BookOpenCheck, LogIn as LogInIcon, LogOut as LogOutIcon, UserCircle, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Button from './ui/Button';
-import LoginModal from '../auth/LoginModal';
-import SignupModal from '../auth/SignupModal';
-import ForgotPasswordModal from '../auth/ForgotPasswordModal';
+import LoginModal from './auth/LoginModal';
+import SignupModal from './auth/SignupModal';
+import ForgotPasswordModal from './auth/ForgotPasswordModal';
 import { useAuth } from '../contexts/AuthContext';
 
 const Header: React.FC = () => {


### PR DESCRIPTION
## Summary
- correct relative paths for auth modals in `Header`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a6ce26148832399860b37ccf94c29