### PR TITLE
Fix article fallback and course details

### DIFF
--- a/constants.tsx
+++ b/constants.tsx
@@ -462,6 +462,10 @@ export const COURSES_DATA: Course[] = [
         title: "הכנה למבחן מחוננים שלב ב' - כיתות ב'-ג'",
         icon: Brain,
         description: 'קורס מקיף להכנה למבחן מחוננים שלב ב\'',
+        detailedContent: `## על הקורס
+קורס זה מספק הכנה מקיפה למבחן מחוננים שלב ב'.
+התלמידים מתרגלים סוגי שאלות נפוצים ולומדים אסטרטגיות פתרון יעילות.
+>>> TIP: מומלץ להתחיל להתכונן מספר חודשים מראש.`,
         links: [{ label: 'למידע נוסף', href: '/shop' }],
         color: 'bg-gradient-to-br from-teal-500 to-cyan-600',
         price: '₪790'
@@ -471,6 +475,9 @@ export const COURSES_DATA: Course[] = [
         title: 'הכנה לתוכנית ההאצה של אוניברסיטת בר-אילן',
         icon: TrendingUp,
         description: 'קורס הכנה ייעודי למבחני קבלה לתוכנית ההאצה.',
+        detailedContent: `## מה בתוכנית
+הקורס מתמקד בחומר הנדרש למבחני הסינון של אוניברסיטת בר‑אילן ומעניק כלים להתמודדות עם ראיונות.
+>>> INFO: ההשתתפות מקנה יתרון משמעותי בקבלה לתוכנית.`,
         links: [{ label: 'למידע נוסף', href: '/shop' }],
         color: 'bg-gradient-to-br from-indigo-500 to-purple-600',
         price: '₪850'
@@ -480,6 +487,9 @@ export const COURSES_DATA: Course[] = [
         title: 'הכנה לתוכנית אודיסאה',
         icon: Rocket,
         description: 'קורס ממוקד למבחני הקבלה של תוכנית אודיסאה.',
+        detailedContent: `## למה כדאי
+המסלול כולל שיעורים מעשיים ותרגול בחינות מהעבר.
+התלמידים נחשפים לנושאים מדעיים מתקדמים ומפתחים מיומנויות למידה עצמאית.`,
         links: [{ label: 'למידע נוסף', href: '/shop' }],
         color: 'bg-gradient-to-br from-purple-500 to-pink-600',
         price: '₪900'

--- a/pages/FullArticlePage.tsx
+++ b/pages/FullArticlePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { APP_NAME } from '../constants';
+import { APP_NAME, ARTICLES_DATA } from '../constants';
 import AnimatedDiv from '../components/ui/AnimatedDiv';
 import Button from '../components/ui/Button';
 import { CalendarDays, UserCircle, Tag, ArrowLeft, Edit3, Share2, ChevronsLeft, Award, SearchX } from 'lucide-react';
@@ -183,7 +183,13 @@ const FullArticlePage: React.FC = () => {
 
                 if (supabaseError) {
                     if (supabaseError.code === 'PGRST116') { // PostgREST error for "No rows found"
-                         setArticle(null); // Article not found
+                        // Try to find the article in local constants as a fallback
+                        const localArticle = ARTICLES_DATA.find(a => (a.artag || a.id) === articleId);
+                        if (localArticle) {
+                            setArticle(localArticle);
+                        } else {
+                            setArticle(null); // Article not found anywhere
+                        }
                     } else {
                         throw supabaseError;
                     }
@@ -201,7 +207,13 @@ const FullArticlePage: React.FC = () => {
                     };
                     setArticle(transformed);
                 } else {
-                     setArticle(null); // Article not found
+                    // If not found in Supabase, try local constants
+                    const localArticle = ARTICLES_DATA.find(a => (a.artag || a.id) === articleId);
+                    if (localArticle) {
+                        setArticle(localArticle);
+                    } else {
+                        setArticle(null); // Article not found
+                    }
                 }
             } catch (err: any) {
                 console.error('שגיאה בטעינת המאמר:', err);


### PR DESCRIPTION
## Summary
- ensure `FullArticlePage` loads articles from local constants if not found in Supabase
- add basic `detailedContent` strings to courses so the course modal shows text

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a7dd9f3208323b95ef3bb91dd5d18