### PR TITLE
Fix article load error for slug IDs

### DIFF
--- a/pages/FullArticlePage.tsx
+++ b/pages/FullArticlePage.tsx
@@ -33,8 +33,8 @@ const FullArticlePage: React.FC = () => {
                     .eq('artag', articleId)
                     .single();
 
-                // If not found by slug, attempt fetching by id
-                if (supabaseError && supabaseError.code === 'PGRST116') {
+                // If not found by slug, attempt fetching by numeric id only
+                if (supabaseError && supabaseError.code === 'PGRST116' && /^\d+$/.test(articleId)) {
                     const byId = await supabase
                         .from('articles')
                         .select('*')


### PR DESCRIPTION
## Summary
- handle non-numeric article IDs when loading from Supabase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae66cc3588323bccec31dc97a8070