### PR TITLE
Fix article parser regex for compatibility

### DIFF
--- a/utils/contentParser.ts
+++ b/utils/contentParser.ts
@@ -17,8 +17,8 @@ export const formatArticleContentToHtml = (text: string | undefined): string => 
     const applyInlineStyles = (str: string): string => {
         // Bold: **text**
         str = str.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
-        // Italics: *text* (not surrounded by word characters)
-        str = str.replace(/(?<!\w)\*(?!\*)([^*]+?)\*(?!\w|\*)/g, '<em>$1</em>');
+        // Italics: *text* (avoid lookbehind for better browser support)
+        str = str.replace(/(^|[^*\\w])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
         // Strikethrough: ~~text~~
         str = str.replace(/~~(.*?)~~/g, '<del>$1</del>');
         // Inline Code: `code`

--- a/utils/courseContentParser.ts
+++ b/utils/courseContentParser.ts
@@ -37,7 +37,7 @@ export const formatCourseDetailedContentToHtml = (text: string | undefined): str
     const applyInlineStyles = (str: string): string => {
         return str
             .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') // Bold
-            .replace(/(?<!\w)(?<!\*)\*(?!\*)([^*]+?)(?<!\*)\*(?!\w)(?!\*)/g, '<em>$1</em>') // Italic
+            .replace(/(^|[^*\\w])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>') // Italic without lookbehind
             .replace(/<sup>(.*?)<\/sup>/g, '<sup class="text-xs opacity-70 ms-0.5">$1</sup>'); // Superscript for citations
     };
 


### PR DESCRIPTION
## Summary
- avoid regex lookbehinds in `contentParser.ts`
- avoid regex lookbehinds in `courseContentParser.ts`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684ae9400a488323a358cd2a761206f3