### PR TITLE
Fix header profile import

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,7 +11,7 @@ import LoginModal from './auth/LoginModal';
 import SignupModal from './auth/SignupModal';
 import ForgotPasswordModal from './auth/ForgotPasswordModal';
 import { useAuth } from '../contexts/AuthContext';
-import { ProfileModal } from '../profile'; // Step 1: Import ProfileModal
+import { ProfileModal } from './profile'; // Step 1: Import ProfileModal
 
 const Header: React.FC = () => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);


### PR DESCRIPTION
## Summary
- correct path to `ProfileModal` import

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af8dcd9448323a0c0218dcb80c090