### PR TITLE
Cache data with context

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import FAQPage from './pages/FAQPage';
 const AdminPage = lazy(() => import('./pages/AdminPage'));
 import { DarkModeContext, DarkMode } from './contexts/DarkModeContext';
 import { AuthProvider } from './contexts/AuthContext'; // Import AuthProvider
+import { DataProvider } from './contexts/DataContext';
 
 // Utility component to scroll to top on route change
 const ScrollToTop: React.FC = () => {
@@ -55,7 +56,8 @@ const App: React.FC = () => {
 
     return (
         <DarkModeContext.Provider value={{ darkMode, toggleDarkMode }}>
-            <AuthProvider> {/* Wrap HashRouter with AuthProvider */}
+            <AuthProvider>
+                <DataProvider>
                 <HashRouter>
                     <ScrollToTop />
                     <div className="flex flex-col min-h-screen bg-slate-50 dark:bg-slate-900 transition-colors duration-300">
@@ -85,6 +87,7 @@ const App: React.FC = () => {
                         <ChatWidget />
                     </div>
                 </HashRouter>
+                </DataProvider>
             </AuthProvider>
         </DarkModeContext.Provider>
     );

--- a/components/sections/ArticlesSection.tsx
+++ b/components/sections/ArticlesSection.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
-import { ARTICLES_DATA } from '../../constants';
 import { Article } from '../../types'; // Ensure Article type is imported
 import AnimatedDiv from '../ui/AnimatedDiv';
 import Button from '../ui/Button';
 import { CalendarDays, UserCircle, Tag, ChevronLeft } from 'lucide-react';
-import { supabase } from '../../utils/supabaseClient'; // Import supabase client
+import { useData } from '../../contexts/DataContext';
 
 interface ArticleCardProps {
     article: Article;
@@ -79,68 +78,8 @@ interface ArticlesSectionProps {
 }
 
 const ArticlesSection: React.FC<ArticlesSectionProps> = ({ maxItems, showTitle = true }) => {
-    const [allArticles, setAllArticles] = useState<Article[]>(ARTICLES_DATA);
-    const [error, setError] = useState<string | null>(null);
-
-    useEffect(() => {
-        const fetchArticles = async () => {
-            try {
-                // Assuming 'articles' is your table name in Supabase
-                // and columns match the Article type.
-                // Ensure Supabase returns `id` as string or cast it.
-                // Ensure date format is consistent or parse/format it.
-                const { data: supabaseArticles, error: supabaseError } = await supabase
-                    .from('articles') // Make sure this table name is correct
-                    .select('*'); // Select all columns, adjust if needed
-
-                if (supabaseError) {
-                    console.error('Error fetching articles from Supabase:', supabaseError);
-                    setError('Failed to load articles from database. Error: ' + supabaseError.message);
-                    // Keep existing articles if fetch fails
-                    setAllArticles(ARTICLES_DATA);
-                    return;
-                }
-
-                if (supabaseArticles) {
-                    // Transform Supabase data to match our Article interface
-                    const fetchedArticles: Article[] = supabaseArticles.map((supaArticle: any) => {
-                        const created = supaArticle.date || supaArticle.created_at;
-                        const bodyText: string = supaArticle.fullContent || supaArticle.body || '';
-
-                        return {
-                            ...supaArticle,
-                            fullContent: bodyText,
-                            excerpt: supaArticle.excerpt || bodyText.substring(0, 150),
-                            author: supaArticle.author || 'צוות מכון אביב',
-                            imageUrl: supaArticle.imageUrl,
-                            date: created ? new Date(created).toLocaleDateString('he-IL', { day: '2-digit', month: '2-digit', year: 'numeric' }) : 'N/A',
-                            id: String(supaArticle.id),
-                        } as Article;
-                    });
-
-                    // Combine and remove duplicates (preferring Supabase articles if IDs clash)
-                    const combinedArticles = [
-                        ...fetchedArticles,
-                        ...ARTICLES_DATA.filter(localArticle =>
-                            !fetchedArticles.find(fetched => String(fetched.id) === String(localArticle.id))
-                        )
-                    ];
-                    setAllArticles(combinedArticles);
-                } else {
-                    // No articles from Supabase, just use local ones
-                    setAllArticles(ARTICLES_DATA);
-                }
-            } catch (err) {
-                console.error('Error in fetchArticles:', err);
-                setError('An unexpected error occurred while fetching articles.');
-                setAllArticles(ARTICLES_DATA); // Fallback to local data
-            }
-        };
-
-        fetchArticles();
-    }, []);
-
-    const articlesToDisplay = maxItems ? allArticles.slice(0, maxItems) : allArticles;
+    const { articles, error } = useData();
+    const articlesToDisplay = maxItems ? articles.slice(0, maxItems) : articles;
 
     return (
         <section className="py-16 sm:py-20 md:py-24 bg-slate-100 dark:bg-slate-900">
@@ -172,7 +111,7 @@ const ArticlesSection: React.FC<ArticlesSectionProps> = ({ maxItems, showTitle =
                     ))}
                 </div>
 
-                {maxItems && allArticles.length > maxItems && (
+                {maxItems && articles.length > maxItems && (
                     <AnimatedDiv animation="fadeInUp" delay={0.5} className="text-center mt-12 sm:mt-16">
                         <Button href="/articles" variant="primary" size="lg">
                             לכל המאמרים

--- a/contexts/DataContext.tsx
+++ b/contexts/DataContext.tsx
@@ -1,0 +1,157 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { supabase } from '../utils/supabaseClient';
+import { ARTICLES_DATA, FAQ_DATA } from '../constants';
+import { Article, FAQCategory } from '../types';
+
+interface DataContextType {
+  articles: Article[];
+  faqs: FAQCategory[];
+  loading: boolean;
+  error: string | null;
+  refreshData: () => Promise<void>;
+}
+
+const DataContext = createContext<DataContextType | undefined>(undefined);
+
+interface DataProviderProps { children: ReactNode; }
+
+export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
+  const [articles, setArticles] = useState<Article[]>(ARTICLES_DATA);
+  const [faqs, setFaqs] = useState<FAQCategory[]>(FAQ_DATA);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchArticles = async () => {
+    try {
+      const { data: supabaseArticles, error: supabaseError } = await supabase
+        .from('articles')
+        .select('*');
+
+      if (supabaseError) {
+        console.error('Error fetching articles from Supabase:', supabaseError);
+        setError('Failed to load articles from database. Error: ' + supabaseError.message);
+        setArticles(ARTICLES_DATA);
+        return;
+      }
+
+      if (supabaseArticles) {
+        const fetchedArticles: Article[] = supabaseArticles.map((supaArticle: any) => {
+          const created = supaArticle.date || supaArticle.created_at;
+          const bodyText: string = supaArticle.fullContent || supaArticle.body || '';
+          return {
+            ...supaArticle,
+            fullContent: bodyText,
+            excerpt: supaArticle.excerpt || bodyText.substring(0, 150),
+            author: supaArticle.author || 'צוות מכון אביב',
+            imageUrl: supaArticle.imageUrl,
+            date: created ? new Date(created).toLocaleDateString('he-IL', { day: '2-digit', month: '2-digit', year: 'numeric' }) : 'N/A',
+            id: String(supaArticle.id),
+          } as Article;
+        });
+        const combinedArticles = [
+          ...fetchedArticles,
+          ...ARTICLES_DATA.filter(localArticle =>
+            !fetchedArticles.find(fetched => String(fetched.id) === String(localArticle.id))
+          )
+        ];
+        setArticles(combinedArticles);
+      } else {
+        setArticles(ARTICLES_DATA);
+      }
+    } catch (err) {
+      console.error('Error in fetchArticles:', err);
+      setError('An unexpected error occurred while fetching articles.');
+      setArticles(ARTICLES_DATA);
+    }
+  };
+
+  const fetchFaqs = async () => {
+    try {
+      const { data: supabaseFaqItems, error: supabaseError } = await supabase
+        .from('qa')
+        .select('id, question_text, answer_text');
+
+      if (supabaseError) {
+        console.error('Error fetching FAQ data from Supabase:', supabaseError);
+        setError('Failed to load some Q&A from the database. Error: ' + supabaseError.message);
+        setFaqs(FAQ_DATA);
+        return;
+      }
+
+      if (supabaseFaqItems && supabaseFaqItems.length > 0) {
+        const supabaseCategories: { [key: string]: FAQCategory } = {};
+        const defaultCategoryId = 'supabase_qa';
+        const defaultCategoryTitle = 'שאלות שאתם שאלתם אותנו';
+
+        supabaseFaqItems.forEach(item => {
+          if (!supabaseCategories[defaultCategoryId]) {
+            supabaseCategories[defaultCategoryId] = {
+              id: defaultCategoryId,
+              title: defaultCategoryTitle,
+              questions: [],
+            };
+          }
+          supabaseCategories[defaultCategoryId].questions.push({
+            id: String(item.id),
+            question: item.question_text,
+            answer: item.answer_text || '',
+          });
+        });
+
+        const fetchedCategoriesArray = Object.values(supabaseCategories);
+        let combinedData = [...FAQ_DATA];
+
+        fetchedCategoriesArray.forEach(supaCategory => {
+          const existingCategoryIndex = combinedData.findIndex(
+            localCat => localCat.title.trim().toLowerCase() === supaCategory.title.trim().toLowerCase()
+          );
+
+          if (existingCategoryIndex > -1) {
+            const existingQuestions = combinedData[existingCategoryIndex].questions;
+            supaCategory.questions.forEach(supaQuestion => {
+              if (!existingQuestions.find(q => q.id === supaQuestion.id)) {
+                existingQuestions.push(supaQuestion);
+              }
+            });
+            combinedData[existingCategoryIndex].questions = [...existingQuestions];
+          } else {
+            combinedData.push(supaCategory);
+          }
+        });
+
+        setFaqs(combinedData);
+      } else {
+        setFaqs(FAQ_DATA);
+      }
+    } catch (err) {
+      console.error('Error in fetchFaqData:', err);
+      setError('An unexpected error occurred while fetching Q&A.');
+      setFaqs(FAQ_DATA);
+    }
+  };
+
+  const refreshData = async () => {
+    setLoading(true);
+    await Promise.all([fetchArticles(), fetchFaqs()]);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    refreshData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <DataContext.Provider value={{ articles, faqs, loading, error, refreshData }}>
+      {children}
+    </DataContext.Provider>
+  );
+};
+
+export const useData = (): DataContextType => {
+  const context = useContext(DataContext);
+  if (context === undefined) {
+    throw new Error('useData must be used within a DataProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- create `DataContext` that loads articles and FAQs from Supabase once
- wrap app with `DataProvider`
- use data from the provider in articles section, FAQ page and full article page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b005082fc8323bd83c834ecc54807