### PR TITLE
feat: Implement AI Telegram messaging and contact form enhancements

### DIFF
--- a/components/sections/ContactSection.tsx
+++ b/components/sections/ContactSection.tsx
@@ -10,16 +10,30 @@ type SubmissionStatus = 'idle' | 'loading' | 'success' | 'error';
 const WORKER_URL = 'https://machon.hillelben14.workers.dev/';
 
 const ContactSection: React.FC = () => {
-    const { user } = useAuth();
+    const { user, profile } = useAuth();
     const [formData, setFormData] = useState({ name: '', email: '', message: '' });
     const [submissionStatus, setSubmissionStatus] = useState<SubmissionStatus>('idle');
     const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
 
     useEffect(() => {
-        if (user?.email && user.email.toLowerCase().endsWith('@gmail.com')) {
-            setFormData(prev => prev.email ? prev : { ...prev, email: user.email! });
-        }
-    }, [user]);
+        setFormData(prev => {
+            let newEmail = prev.email;
+            let newName = prev.name;
+
+            if (user?.email && !prev.email) {
+                newEmail = user.email;
+            }
+
+            if (profile?.fullName && !prev.name) {
+                newName = profile.fullName;
+            }
+            // Only update state if something actually changed to avoid potential infinite loops
+            if (newEmail !== prev.email || newName !== prev.name) {
+               return { ...prev, email: newEmail, name: newName };
+            }
+            return prev; // No changes needed
+        });
+    }, [user, profile]); // Add profile to dependency array
 
 
     const getWhatsAppNumber = (phone: string) => {


### PR DESCRIPTION
This commit introduces two main features:

1.  **AI Telegram Messaging:**
    *   Logged-in users can now ask the AI chat widget to send messages to the site owner.
    *   My system prompt is dynamically updated to inform me of this capability if you are authenticated and have a name/email.
    *   I am instructed to use a special command to trigger the message sending.
    *   The `ChatWidget` intercepts this command, extracts the message, and calls a new `sendTelegramMessageToOwner` function.
    *   This function sends your name, email (from `AuthContext`), and the message content to a conceptual backend endpoint for actual dispatch via Telegram.
    *   You will receive chat notifications about the sending process and its success/failure.
    *   If you are not logged in, I am unaware of this feature.

2.  **Contact Form Autofill:**
    *   The contact form (`ContactSection.tsx`) now autofills your full name and email address if you are logged in and these fields are available in your `AuthContext` profile.
    *   This enhances your experience by pre-filling known information.

The changes involve modifications to `ContactSection.tsx` for autofill, and extensive updates to `ChatWidget.tsx` for AI integration, context awareness, dynamic prompting, and message sending logic. `AuthContext.tsx` was reviewed and confirmed to support these features without changes.

Note: The Telegram message sending relies on a backend update to handle the `/send-telegram` endpoint, which is detailed conceptually in the plan but not part of this frontend commit.