### PR TITLE
Fix: Correct column name for admin authorization check

### DIFF
--- a/pages/AdminPage.tsx
+++ b/pages/AdminPage.tsx
@@ -398,8 +398,8 @@ const AdminPage: React.FC = () => {
       try {
         const { data, error } = await supabase
           .from('admin')
-          .select('id, email, expires_at') // Ensure 'email' is the correct column name
-          .eq('email', user.email) // Query by the user's email
+          .select('id, gmail, expires_at') // Ensure 'email' is the correct column name
+          .eq('gmail', user.email) // Query by the user's email
           .single();
 
         if (error && error.code !== 'PGRST116') { // PGRST116: No rows found
@@ -758,8 +758,7 @@ ${currentBody}
     try {
       const { data, error } = await supabase.from('admin').select('*').order('created_at', { ascending: false });
       if (error) throw error;
-      // Assuming 'gmail' column in 'admin' table needs to be mapped to 'email' in SiteAdmin
-      setAdminsList(data ? data.map(item => ({ ...item, email: item.gmail || item.email })) : []);
+      setAdminsList(data || []);
     } catch (err: any) {
       setErrorAdmins(`שגיאה בטעינת רשימת המנהלים: ${err.message}`);
     } finally {

--- a/types.ts
+++ b/types.ts
@@ -11,7 +11,7 @@ export interface NavItem {
 }
 export interface SiteAdmin {
   id: string; // Assuming UUID from Supabase, can be number if auto-incrementing
-  email: string;
+  gmail: string;
   expires_at?: string | null; // ISO date string
   created_at: string; // ISO date string
 }


### PR DESCRIPTION
I resolved a 406 "Not Acceptable" error on the Admin Page. The error was caused by querying the 'admin' table using 'email' as the column name for user email identification and selection, whereas the actual column name in the database is 'gmail'.

Changes made:
- Modified `checkAdminStatus` in `pages/AdminPage.tsx` to use `gmail` instead of `email` when selecting and filtering admin records from the Supabase 'admin' table.
- Updated the `SiteAdmin` type definition in `types.ts` to use `gmail: string;` instead of `email: string;` to align with the database schema.
- Adjusted the `fetchAdmins` function in `pages/AdminPage.tsx` to correctly map data to the updated `SiteAdmin` type, simplifying the logic as the fetched 'admin' records (using `select('*')`) now directly provide the `gmail` field.

These changes ensure that the admin authorization check and admin data display use the correct database column, resolving the 406 error and allowing the Admin Page to function as intended for authorized users.