### PR TITLE
Fix Supabase Accept header

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useLocation, Link, useNavigate } from 'react-router-dom';
 import { MessageSquare, Send } from 'lucide-react';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import Button from './ui/Button';
 import { useAuth } from '../contexts/AuthContext';
 import ReactMarkdown from 'react-markdown';
@@ -10,11 +9,11 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 
-import { APP_NAME, ARTICLES_DATA, COURSES_DATA, FAQ_DATA, PREVIEW_SECTIONS, SUPABASE_URL, SUPABASE_ANON_KEY } from '../constants.tsx';
+import { APP_NAME, ARTICLES_DATA, COURSES_DATA, FAQ_DATA, PREVIEW_SECTIONS } from '../constants.tsx';
+import { supabase } from '../utils/supabaseClient';
 import { Article, Course, FAQCategory } from '../types.ts';
 
-// Initialize Supabase client
-const supabase: SupabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+// Supabase client is imported
 
 // Simple chat widget using Gemini API
 const GEMINI_API_KEYS = [

--- a/pages/AdminPage.tsx
+++ b/pages/AdminPage.tsx
@@ -400,7 +400,7 @@ const AdminPage: React.FC = () => {
           .from('admin')
           .select('id, gmail, expires_at') // Ensure 'email' is the correct column name
           .eq('gmail', user.email) // Query by the user's email
-          .single();
+          .maybeSingle();
 
         if (error && error.code !== 'PGRST116') { // PGRST116: No rows found
           console.error('Error fetching admin status:', error);

--- a/utils/supabaseClient.ts
+++ b/utils/supabaseClient.ts
@@ -10,4 +10,12 @@ if (!SUPABASE_ANON_KEY) {
   throw new Error("Supabase anonymous key is not defined. Please check your constants.tsx file.");
 }
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const customFetch: typeof fetch = (input, init) => {
+  const headers = new Headers(init?.headers);
+  headers.set('Accept', 'application/json');
+  return fetch(input, { ...init, headers });
+};
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  global: { fetch: customFetch },
+});


### PR DESCRIPTION
## Summary
- connect Supabase from shared client in ChatWidget
- use maybeSingle for admin query to avoid 406 errors
- override Accept header via custom fetch

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684b6d4652688323843de4a91467a089