### PR TITLE
Fix: Correct syntax error in ChatWidget.tsx

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -703,7 +703,7 @@ Only use this command when the user explicitly wants to send a message to the ow
                                 </a>
                               );
                             }
-                            },
+                            }
                             ul: ({node, ...props}) => (
                               <ul className="list-disc pl-5 space-y-1" {...props} />
                             ),


### PR DESCRIPTION
Removes a trailing comma in the ReactMarkdown components prop that was causing a build failure.