### PR TITLE
Fix: Correct syntax error in ChatWidget.tsx

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -702,8 +702,7 @@ Only use this command when the user explicitly wants to send a message to the ow
                                   {children}
                                 </a>
                               );
-                            }
-                            }
+                            },
                             ul: ({node, ...props}) => (
                               <ul className="list-disc pl-5 space-y-1" {...props} />
                             ),


### PR DESCRIPTION
An extra closing curly brace was present in the ReactMarkdown components prop, causing a build failure. This commit removes the extraneous brace.