### PR TITLE
Improve block management and logging

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -79,9 +79,7 @@ const App: React.FC = () => {
         logAppLoad();
     }, []); // Empty dependency array ensures this runs only once on mount
 
-    // Effect for checking block status
-    useEffect(() => {
-        const checkBlockStatus = async () => {
+    const checkBlockStatus = useCallback(async () => {
             setIsLoadingBlockStatus(true);
             try {
                 // 1. Fetch IP
@@ -153,10 +151,15 @@ const App: React.FC = () => {
             } finally {
                 setIsLoadingBlockStatus(false);
             }
-        };
+    }, [supabase]);
 
+    useEffect(() => {
         checkBlockStatus();
-    }, []); // Runs once on app load
+        const { data: { subscription } } = supabase.auth.onAuthStateChange(() => {
+            checkBlockStatus();
+        });
+        return () => subscription.unsubscribe();
+    }, [checkBlockStatus]);
 
     if (isLoadingBlockStatus) {
         return (

--- a/pages/AdminPage.tsx
+++ b/pages/AdminPage.tsx
@@ -1328,7 +1328,7 @@ ${currentBody}
 
           {/* Currently Blocked Items List */}
           <div className="mb-8">
-            <h3 className="text-lg font-medium text-slate-800 dark:text-slate-100 mb-3">פריטים חסומים حاليًا</h3>
+            <h3 className="text-lg font-medium text-slate-800 dark:text-slate-100 mb-3">פריטים חסומים כרגע</h3>
             {isLoadingBlockedItems && (
               <div className="flex flex-col items-center justify-center p-5 text-slate-600 dark:text-slate-400">
                 <Loader2 className="h-8 w-8 animate-spin text-primary dark:text-sky-400" />


### PR DESCRIPTION
## Summary
- subscribe to auth changes when checking block status
- log user activity directly into the DB with IP lookup fallback
- update heading for blocked items list

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e8075d1948323bcb94aaccde0a489