### PR TITLE
Fix article preview markdown handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "tailwind-scrollbar": "^4.0.2",
-        "tiptap-markdown": "^0.8.10"
+        "tiptap-markdown": "^0.8.10",
+        "turndown": "^7.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
@@ -466,6 +467,12 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -4236,6 +4243,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "tailwind-scrollbar": "^4.0.2",
-    "tiptap-markdown": "^0.8.10"
+    "tiptap-markdown": "^0.8.10",
+    "turndown": "^7.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/pages/AdminPage.tsx
+++ b/pages/AdminPage.tsx
@@ -209,10 +209,8 @@ onUpdate: ({ editor: currentEditor }) => {
   setCurrentArticle(prev => {
     if (!prev) return prev;
 
-    const markdownOutput = currentEditor.storage.markdown.getMarkdown();
-    console.log("Refactored Markdown Output (getMarkdown):", markdownOutput); // For debugging
-
-    const correctlySerializedMarkdown = postserializeAlertBlocks(markdownOutput);
+    const htmlOutput = currentEditor.getHTML();
+    const correctlySerializedMarkdown = postserializeAlertBlocks(htmlOutput);
     const updated = { ...prev, fullContent: correctlySerializedMarkdown };
 
     localStorage.setItem('draftArticle', JSON.stringify(updated));

--- a/utils/alertBlockMarkdownParser.ts
+++ b/utils/alertBlockMarkdownParser.ts
@@ -1,3 +1,5 @@
+import TurndownService from 'turndown';
+
 /**
  * Converts raw Markdown text for >>> ALERT: blocks into an intermediate HTML representation
  * that Tiptap's AlertBlockNode can parse.
@@ -38,83 +40,26 @@ export function preparseAlertBlocks(markdown: string): string {
  * This version attempts a more robust replacement strategy.
  */
 export function postserializeAlertBlocks(htmlOutput: string): string {
-  const ALERT_TYPES = ['INFO', 'TIP', 'NOTE', 'WARNING']; // Add this line
+  const ALERT_TYPES = ['INFO', 'TIP', 'NOTE', 'WARNING'];
   if (typeof window === 'undefined' || !htmlOutput) {
     return htmlOutput;
   }
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(htmlOutput, 'text/html');
-  const tempDoc = document.implementation.createHTMLDocument(''); // Use a proper document for manipulation
 
-  // Iterate over a static copy of the nodes, as we'll be modifying the live list
   const alertDivs = Array.from(doc.querySelectorAll('div[data-alert-block][data-alert-type]'));
+
+  const turndown = new TurndownService();
 
   alertDivs.forEach(div => {
     const alertType = div.getAttribute('data-alert-type')?.toUpperCase();
-    if (!alertType || !ALERT_TYPES.includes(alertType)) {
-      return;
-    }
+    if (!alertType || !ALERT_TYPES.includes(alertType)) return;
 
-    let innerMarkdownContent = '';
-    // Process child nodes (expected to be <p> tags or text directly)
-    div.childNodes.forEach((pNode, index) => {
-        let lineContent = '';
-        if (pNode.nodeName === 'P') {
-            pNode.childNodes.forEach(inlineNode => {
-                if (inlineNode.nodeType === Node.TEXT_NODE) {
-                    lineContent += inlineNode.textContent;
-                } else if (inlineNode.nodeType === Node.ELEMENT_NODE) {
-                    const el = inlineNode as HTMLElement;
-                    // This simple conversion assumes innerHTML of inline elements is plain text.
-                    // For nested structures, this would need to be recursive.
-                    switch(el.nodeName) {
-                        case 'STRONG': case 'B': lineContent += `**${el.textContent || ''}**`; break;
-                        case 'EM': case 'I': lineContent += `_${el.textContent || ''}_`; break;
-                        case 'A': lineContent += `[${el.textContent || ''}](${el.getAttribute('href') || ''})`; break;
-                        case 'CODE': lineContent += `\`${el.textContent || ''}\``; break;
-                        case 'BR': lineContent += '\n'; break;
-                        default: lineContent += el.textContent || ''; // Fallback for unknown inline tags: strip tag, keep text
-                    }
-                }
-            });
-        } else if (pNode.nodeType === Node.TEXT_NODE) {
-            lineContent = pNode.textContent || '';
-        }
-        // Add newline if it's not the first line and previous content wasn't empty
-        if (index > 0 && innerMarkdownContent.length > 0 && (lineContent || '').trim().length > 0) {
-          innerMarkdownContent += '\n';
-        }
-        innerMarkdownContent += (lineContent || '').trim();
-    });
-
-    const markdownBlock = `>>> ${alertType}: ${(innerMarkdownContent || '').trim()}`;
-
-    // Replace the original div with a text node containing the newlines and markdown block
-    // This ensures block separation.
-    const replacementNode = tempDoc.createTextNode(`\n\n${markdownBlock}\n\n`);
+    const innerMarkdown = turndown.turndown(div.innerHTML).trim();
+    const replacementNode = doc.createTextNode(`\n\n>>> ${alertType}: ${innerMarkdown}\n\n`);
     div.parentNode?.replaceChild(replacementNode, div);
   });
 
-  // Serialize the modified document body back to an HTML string.
-  // Then, to get a "cleaner" output that's just the content (without html/body tags):
-  // Create a temporary div, append all children of body to it, then get its innerHTML.
-  // This helps remove the surrounding <html><body> tags from the output.
-  const finalBody = doc.body;
-  // If the original htmlOutput was a fragment, body might not be what we want.
-  // However, DOMParser always creates a full HTML document.
-  // We need to handle cases where original htmlOutput might not have a body.
-  // For simplicity, if only one child was in body (our content), use its outerHTML or textContent.
-
-  if (finalBody.childNodes.length === 1 && finalBody.firstChild?.nodeType === Node.TEXT_NODE) {
-      return finalBody.firstChild.textContent || ''; // If it became a single text node
-  }
-
-  // A more general approach to reconstruct the string:
-  // Create a temporary container, append all children of the parsed body to it.
-  const container = tempDoc.createElement('div');
-  while (doc.body.firstChild) {
-    container.appendChild(doc.body.firstChild);
-  }
-  return container.innerHTML;
+  return turndown.turndown(doc.body.innerHTML).trim();
 }


### PR DESCRIPTION
## Summary
- convert tiptap HTML to markdown when updating articles
- use Turndown to process custom alert blocks
- add turndown dependency

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e9e696e508323ba365310241abc12