### PR TITLE
Fix: Ensure reliable user logout and state clearing

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -164,9 +164,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const logout = async () => {
     setLoadingInitial(true); // Indicate loading during logout
-    await supabase.auth.signOut();
-    // onAuthStateChange will handle setting user, session, profile to null
-    // setLoadingInitial will be set to false by onAuthStateChange listener
+    const { error } = await supabase.auth.signOut();
+
+    if (error) {
+      console.error("Error logging out:", error);
+      setLoadingInitial(false);
+      throw error;
+    } else {
+      setSession(null);
+      setUser(null);
+      setProfile(null);
+      loginNotifiedRef.current = false;
+      logActivity('SIGNED_OUT');
+      setLoadingInitial(false);
+    }
   };
 
   // Login and Signup functions are currently handled by the modals.


### PR DESCRIPTION
I've made the user logout process more robust by explicitly clearing session, user, and profile states within the AuthContext's logout function. This directly addresses an issue where the application state might not update correctly upon logout if the onAuthStateChange listener didn't fire or process the SIGNED_OUT event as expected.

Modifications:
- Updated `AuthContext.logout()`:
  - Now directly sets session, user, and profile states to null upon successful `supabase.auth.signOut()`.
  - Manages `loadingInitial` state directly within the function, setting it to false after completion or error.
  - Logs the 'SIGNED_OUT' event.
  - Propagates errors from `signOut()` to be caught by UI components (e.g., ProfileModal) for user feedback.
- Verified `onAuthStateChange` listener:
  - Confirmed its existing logic for handling SIGNED_OUT events is compatible and acts as a reliable fallback for state clearing.

This change ensures that you are logged out effectively and the UI reflects the correct authentication state.