### PR TITLE
feat: Add Learning Space button with authorization

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import ShopPage from './pages/ShopPage';
 import ContactPage from './pages/ContactPage';
 import FullArticlePage from './pages/FullArticlePage';
 import FAQPage from './pages/FAQPage';
+import LearningSpacePage from './pages/LearningSpacePage'; // Import LearningSpacePage
 const AdminPage = lazy(() => import('./pages/AdminPage'));
 import { DarkModeContext, DarkMode } from './contexts/DarkModeContext';
 import { fetchIpWithFallback } from './utils/ipUtils'; // Import the new IP fetching function
@@ -195,6 +196,7 @@ const App: React.FC = () => {
                                     <Route path="/shop" element={<ShopPage />} />
                                     <Route path="/contact" element={<ContactPage />} />
                                     <Route path="/faq" element={<FAQPage />} />
+                                    <Route path="/learning-space" element={<LearningSpacePage />} />
                                     <Route
                                         path="/admin"
                                         element={

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,7 @@ import { APP_NAME, NAVIGATION_ITEMS } from '../constants';
 import { NavItem } from '../types';
 import DarkModeToggle from './DarkModeToggle';
 // LogOutIcon removed, UserCircle is used
-import { Menu, X, ExternalLink as ExternalLinkIcon, BookOpenCheck, LogIn as LogInIcon, UserCircle, Loader2 } from 'lucide-react';
+import { Menu, X, ExternalLink as ExternalLinkIcon, BookOpenCheck, LogIn as LogInIcon, UserCircle, Loader2, BookText } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Button from './ui/Button';
 import LoginModal from './auth/LoginModal';
@@ -18,7 +18,7 @@ const Header: React.FC = () => {
     const [isProfileModalOpen, setIsProfileModalOpen] = useState(false); // Step 2: Add state for modal visibility
     const [isScrolled, setIsScrolled] = useState(false);
     const location = useLocation();
-    const { user, profile, logout, loadingInitial } = useAuth(); // Consume AuthContext
+    const { user, profile, logout, loadingInitial, isLearningSpaceAuthorized } = useAuth(); // Consume AuthContext
 
     const [activeModal, setActiveModal] = useState<'login' | 'signup' | 'forgotPassword' | null>(null);
     const [loginPrefill, setLoginPrefill] = useState<{email?: string; password?: string} | null>(null);
@@ -70,6 +70,15 @@ const Header: React.FC = () => {
     // };
 
     // Removed commented out handleLogout function for cleaner diff
+
+    // Filter navigation items based on authorization status
+    const visibleNavigationItems = NAVIGATION_ITEMS.filter(item => {
+        if (item.href === '/learning-space') {
+            return !loadingInitial && isLearningSpaceAuthorized;
+        }
+        return true; // Keep all other items
+    });
+
     const NavLinkContent: React.FC<{ item: NavItem; mobile?: boolean }> = ({ item, mobile }) => {
         const MainIconComponent = item.icon;
         return (
@@ -192,7 +201,7 @@ const Header: React.FC = () => {
                         </div>
 
                         <nav className="hidden lg:flex items-center space-s-1 rtl:space-s-reverse">
-                            {NAVIGATION_ITEMS.map((item) => (
+                            {visibleNavigationItems.map((item) => (
                                 <div key={item.label} className="ms-3 rtl:me-3">
                                     <NavLink item={item} />
                                 </div>
@@ -229,7 +238,7 @@ const Header: React.FC = () => {
                             className="lg:hidden bg-white dark:bg-secondary-dark shadow-2xl absolute top-full left-0 right-0 overflow-y-auto max-h-[calc(100vh-5rem)] border-t border-gray-200 dark:border-gray-700"
                         >
                             <nav className="flex flex-col px-2 pt-3 pb-5 space-y-1.5">
-                                {NAVIGATION_ITEMS.map((item) => (
+                                {visibleNavigationItems.map((item) => (
                                     <NavLink key={item.label} item={item} mobile />
                                 ))}
                                 {/* Example of adding auth button to mobile menu if not in toolbar

--- a/constants.tsx
+++ b/constants.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavItem, Course, Article } from './types'; // Combined Article import
-import { ExternalLink, Facebook, Instagram, MessageCircle, Rss, ShoppingBag, Info, Home, BookOpen, Users, BarChart2, Award, UsersRound, Edit3, Lightbulb, ChevronRight, Send, Phone, BookOpenCheck, Tv, Settings, Target, TrendingUp, Brain, CheckCircle, Star as StarIcon, Users as UsersIcon, Smile, Award as AwardIcon, MessageSquareQuote, Activity, Briefcase, GraduationCap, Zap, Rocket, ClipboardCheck, HelpCircle } from 'lucide-react'; // Added HelpCircle
+import { BookText, ExternalLink, Facebook, Instagram, MessageCircle, Rss, ShoppingBag, Info, Home, BookOpen, Users, BarChart2, Award, UsersRound, Edit3, Lightbulb, ChevronRight, Send, Phone, BookOpenCheck, Tv, Settings, Target, TrendingUp, Brain, CheckCircle, Star as StarIcon, Users as UsersIcon, Smile, Award as AwardIcon, MessageSquareQuote, Activity, Briefcase, GraduationCap, Zap, Rocket, ClipboardCheck, HelpCircle } from 'lucide-react'; // Added HelpCircle, BookText
 
 
 export const LOGO_URL = 'text_logo'; // Indicates text logo is used, actual text comes from APP_NAME
@@ -14,6 +14,7 @@ export const NAVIGATION_ITEMS: NavItem[] = [
     { label: 'מאמרים', href: '/articles', icon: Rss },
     { label: 'חנות', href: '/shop', icon: ShoppingBag },
     { label: 'שאלות', href: '/faq', icon: HelpCircle }, // Changed from "חנות חיצונית"
+    { label: 'מקום לימוד', href: '/learning-space', icon: BookText, isButton: false },
     { label: 'צור קשר', href: '/contact', isButton: false, icon: Send },
 ];
 

--- a/pages/AdminPage.tsx
+++ b/pages/AdminPage.tsx
@@ -4,8 +4,8 @@ import { useAuth } from '../contexts/AuthContext'; // Added import
 import { SupabaseClient } from '@supabase/supabase-js'; // createClient removed
 import { supabase } from '../utils/supabaseClient'; // Added import
 import { APP_NAME } from '../constants'; // SUPABASE_URL, SUPABASE_ANON_KEY removed
-import { PlusCircle, Edit2, Trash2, XCircle, Loader2, Sparkles as SparklesIcon } from 'lucide-react'; // Added SparklesIcon
-import { SiteAdmin } from '../types'; // Corrected path
+import { PlusCircle, Edit2, Trash2, XCircle, Loader2, Sparkles as SparklesIcon, Users } from 'lucide-react'; // Added SparklesIcon, Users
+import { SiteAdmin, AuthorizedLearningSpaceUser } from '../types'; // Corrected path, Added AuthorizedLearningSpaceUser
 import { useEditor, EditorContent } from '@tiptap/react';
 import { formatArticleContentToHtml } from '../utils/contentParser';
 import StarterKit from '@tiptap/starter-kit';
@@ -95,6 +95,13 @@ const AdminPage: React.FC = () => {
   const [newBlockType, setNewBlockType] = useState<'IP' | 'EMAIL'>('IP');
   const [newBlockReason, setNewBlockReason] = useState('');
   const [isSubmittingBlock, setIsSubmittingBlock] = useState(false);
+
+  // State for Authorized Learning Space Users Management
+  const [authorizedLearningSpaceUsers, setAuthorizedLearningSpaceUsers] = useState<AuthorizedLearningSpaceUser[]>([]);
+  const [isLoadingAuthLearningUsers, setIsLoadingAuthLearningUsers] = useState(false);
+  const [errorAuthLearningUsers, setErrorAuthLearningUsers] = useState<string | null>(null);
+  const [newAuthLearningEmail, setNewAuthLearningEmail] = useState('');
+  const [isSubmittingAuthLearningEmail, setIsSubmittingAuthLearningEmail] = useState(false);
 
   const editor = useEditor({
     extensions: [
@@ -1044,8 +1051,77 @@ ${currentBody}
       fetchBlockedItems();
       fetchUserActivityIPs();
       fetchUserActivityEmails();
+      fetchAuthorizedLearningSpaceUsers();
     }
-  }, [isAuthorized, supabase, fetchArticles, fetchQAItems, fetchAdmins, fetchBlockedItems, fetchUserActivityIPs, fetchUserActivityEmails]);
+  }, [isAuthorized, supabase, fetchArticles, fetchQAItems, fetchAdmins, fetchBlockedItems, fetchUserActivityIPs, fetchUserActivityEmails, fetchAuthorizedLearningSpaceUsers]);
+
+  // CRUD Functions for Authorized Learning Space Users
+  const fetchAuthorizedLearningSpaceUsers = useCallback(async () => {
+    if (!supabase) return;
+    setIsLoadingAuthLearningUsers(true);
+    setErrorAuthLearningUsers(null);
+    try {
+      const { data, error } = await supabase
+        .from('authorized_learning_space_users')
+        .select('*')
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      setAuthorizedLearningSpaceUsers(data || []);
+    } catch (err: any) {
+      setErrorAuthLearningUsers(`שגיאה בטעינת משתמשים מורשים: ${err.message}`);
+    } finally {
+      setIsLoadingAuthLearningUsers(false);
+    }
+  }, [supabase]);
+
+  const handleAddAuthorizedLearningEmail = async (emailToAdd: string) => {
+    if (!emailToAdd.trim() || !emailToAdd.includes('@')) {
+      setErrorAuthLearningUsers('כתובת אימייל לא תקינה.');
+      return;
+    }
+    setIsSubmittingAuthLearningEmail(true);
+    setErrorAuthLearningUsers(null);
+    try {
+      const newUserData: { email: string; added_by?: string } = {
+        email: emailToAdd.trim(),
+      };
+      if (user?.id) {
+        newUserData.added_by = user.id;
+      }
+      const { error } = await supabase.from('authorized_learning_space_users').insert([newUserData]);
+      if (error) {
+        if (error.code === '23505') { // Unique constraint violation
+          setErrorAuthLearningUsers(`אימייל '${emailToAdd}' כבר קיים ברשימה.`);
+        } else {
+          throw error;
+        }
+      } else {
+        alert(`אימייל '${emailToAdd}' נוסף בהצלחה לרשימת המורשים.`);
+        setNewAuthLearningEmail(''); // Clear input field
+        fetchAuthorizedLearningSpaceUsers(); // Refresh the list
+      }
+    } catch (err: any) {
+      setErrorAuthLearningUsers(`שגיאה בהוספת אימייל מורשה: ${err.message}`);
+    } finally {
+      setIsSubmittingAuthLearningEmail(false);
+    }
+  };
+
+  const handleRemoveAuthorizedLearningEmail = async (userId: string, emailToRemove: string) => {
+    if (!window.confirm(`האם אתה בטוח שברצונך להסיר הרשאה מאימייל '${emailToRemove}'?`)) return;
+    setIsLoadingAuthLearningUsers(true); // Indicate loading for list modification
+    setErrorAuthLearningUsers(null);
+    try {
+      const { error } = await supabase.from('authorized_learning_space_users').delete().eq('id', userId);
+      if (error) throw error;
+      alert(`ההרשאה עבור '${emailToRemove}' הוסרה בהצלחה.`);
+      fetchAuthorizedLearningSpaceUsers(); // Refresh the list
+    } catch (err: any) {
+      setErrorAuthLearningUsers(`שגיאה בהסרת הרשאת אימייל: ${err.message}`);
+    } finally {
+      // setIsLoadingAuthLearningUsers(false); // fetchAuthorizedLearningSpaceUsers will set this
+    }
+  };
 
   const handleAddBlockSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -1479,6 +1555,80 @@ ${currentBody}
               ))}
             </div>
           )}
+        </section>
+
+        {/* Authorized Learning Space Users Management Section */}
+        <section className="bg-white dark:bg-slate-800 p-4 sm:p-6 rounded-xl shadow-lg mt-6 sm:mt-8">
+          <div className="flex justify-between items-center border-b border-slate-300 dark:border-slate-700 pb-4 mb-6">
+            <h2 className="text-xl sm:text-2xl font-semibold text-primary dark:text-sky-500 flex items-center">
+              <Users size={24} className="ml-3" /> ניהול הרשאות למקום לימוד
+            </h2>
+          </div>
+
+          {/* Form for Adding Emails */}
+          <form onSubmit={(e) => { e.preventDefault(); handleAddAuthorizedLearningEmail(newAuthLearningEmail); }} className="mb-6 p-4 border border-slate-200 dark:border-slate-700 rounded-lg bg-slate-50 dark:bg-slate-700/30">
+            <h3 className="text-lg font-medium text-slate-800 dark:text-slate-100 mb-3">הוסף אימייל מורשה</h3>
+            {errorAuthLearningUsers && <div className="p-3 mb-3 text-sm rounded-lg border bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700">{errorAuthLearningUsers}</div>}
+            <div className="flex items-end gap-3">
+              <div className="flex-grow">
+                <label htmlFor="newAuthLearningEmail" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">כתובת אימייל</label>
+                <input
+                  type="email"
+                  id="newAuthLearningEmail"
+                  value={newAuthLearningEmail}
+                  onChange={(e) => setNewAuthLearningEmail(e.target.value)}
+                  className="w-full p-2.5 border border-slate-300 dark:border-slate-600 rounded-lg focus:ring-1 focus:ring-primary dark:bg-slate-700 dark:text-white shadow-sm text-sm"
+                  placeholder="user@example.com"
+                  required
+                  disabled={isSubmittingAuthLearningEmail}
+                />
+              </div>
+              <button
+                type="submit"
+                className="px-4 py-2.5 bg-green-500 hover:bg-green-600 text-white rounded-lg flex items-center shadow-md text-sm font-medium transition-colors disabled:opacity-60"
+                disabled={isSubmittingAuthLearningEmail || !newAuthLearningEmail.trim()}
+              >
+                {isSubmittingAuthLearningEmail ? <Loader2 size={18} className="animate-spin ml-2" /> : <PlusCircle size={18} className="ml-2" />}
+                {isSubmittingAuthLearningEmail ? 'מוסיף...' : 'הוסף אימייל'}
+              </button>
+            </div>
+          </form>
+
+          {/* List of Authorized Emails */}
+          <div>
+            <h3 className="text-lg font-medium text-slate-800 dark:text-slate-100 mb-3">אימיילים מורשים כרגע</h3>
+            {isLoadingAuthLearningUsers && (
+              <div className="flex flex-col items-center justify-center p-5 text-slate-600 dark:text-slate-400">
+                <Loader2 className="h-8 w-8 animate-spin text-primary dark:text-sky-400" />
+                <p className="mt-2 text-xs">טוען רשימת אימיילים מורשים...</p>
+              </div>
+            )}
+            {!isLoadingAuthLearningUsers && errorAuthLearningUsers && <div className="p-3 my-2 text-sm rounded-lg border bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700">{errorAuthLearningUsers}</div>}
+            {!isLoadingAuthLearningUsers && !errorAuthLearningUsers && authorizedLearningSpaceUsers.length === 0 && (
+              <p className="text-slate-500 dark:text-slate-400 text-center py-5 text-sm">לא נמצאו אימיילים מורשים.</p>
+            )}
+            {!isLoadingAuthLearningUsers && !errorAuthLearningUsers && authorizedLearningSpaceUsers.length > 0 && (
+              <div className="space-y-2 max-h-96 overflow-y-auto pr-1">
+                {authorizedLearningSpaceUsers.map(auth_user => (
+                  <div key={auth_user.id} className="p-3 border border-slate-200 dark:border-slate-700 rounded-lg shadow-sm bg-slate-50 dark:bg-slate-700/40 flex justify-between items-center text-sm">
+                    <div>
+                      <p className="font-semibold text-slate-700 dark:text-slate-200">{auth_user.email}</p>
+                      <p className="text-xs text-slate-400 dark:text-slate-500">נוסף בתאריך: {new Date(auth_user.created_at).toLocaleString('he-IL')}</p>
+                      {auth_user.added_by && <p className="text-xs text-slate-400 dark:text-slate-500">נוסף על ידי (ID): {auth_user.added_by}</p>}
+                      {auth_user.notes && <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">הערות: {auth_user.notes}</p>}
+                    </div>
+                    <button
+                      onClick={() => handleRemoveAuthorizedLearningEmail(auth_user.id, auth_user.email)}
+                      className="px-2.5 py-1.5 text-xs font-medium rounded-md flex items-center transition-colors bg-red-500 hover:bg-red-600 text-white"
+                      disabled={isLoadingAuthLearningUsers || isSubmittingAuthLearningEmail}
+                    >
+                      <Trash2 size={14} className="ml-1" />הסר הרשאה
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </section>
 
         {/* User Blocking Management Section */}

--- a/pages/LearningSpacePage.tsx
+++ b/pages/LearningSpacePage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const LearningSpacePage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-slate-100 dark:bg-slate-900 text-slate-800 dark:text-slate-200 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto text-center">
+        <h1 className="text-4xl font-extrabold text-primary dark:text-sky-400 sm:text-5xl lg:text-6xl mb-6">
+          ברוכים הבאים למקום הלימוד!
+        </h1>
+        <p className="text-xl text-slate-700 dark:text-slate-300 leading-relaxed">
+          תוכן מרגש יגיע לכאן בקרוב. אנו עובדים במרץ כדי להביא לכם חווית למידה ייחודית ואיכותית.
+        </p>
+        <p className="mt-4 text-md text-slate-600 dark:text-slate-400">
+          בנתיים, אתם מוזמנים לחקור את שאר האתר שלנו.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LearningSpacePage;

--- a/types.ts
+++ b/types.ts
@@ -16,6 +16,14 @@ export interface SiteAdmin {
   created_at: string; // ISO date string
 }
 
+export interface AuthorizedLearningSpaceUser {
+  id: string; // or number if you use auto-incrementing IDs, but UUID string is typical for Supabase
+  email: string;
+  created_at: string; // ISO date string
+  added_by?: string; // optional, UUID of the admin who added the user
+  notes?: string; // optional
+}
+
 export interface Course {
     id: string;
     title: string;


### PR DESCRIPTION
This commit introduces a new 'Learning Space' button in the header.

Key changes:
- Created a new Supabase table `authorized_learning_space_users` to store emails of users authorized to see the button.
- Added an interface for managing these authorized users in the Admin Page, including fetching, adding, and removing emails.
- Enhanced `AuthContext` to check if the current user is either a site admin (from the `admin` table) or an email in the `authorized_learning_space_users` table. This status is exposed as `isLearningSpaceAuthorized`.
- The 'Learning Space' button in `Header.tsx` is now conditionally rendered based on the `isLearningSpaceAuthorized` status. It's hidden by default and appears only after successful authorization check.
- Added `BookText` icon for the new button.
- Created a placeholder page `LearningSpacePage.tsx` for the new button's destination and updated `App.tsx` with the corresponding route.