### PR TITLE
Fix: Style scrollbar for light/dark themes to prevent white edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,16 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww" crossorigin="anonymous">
 
     <style>
+        :root {
+          --scrollbar-track-color: #f1f5f9; /* Tailwind slate-100 */
+          --scrollbar-thumb-color: #94a3b8; /* Tailwind slate-400 */
+        }
+
+        html.dark {
+          --scrollbar-track-color: #0f172a; /* Tailwind slate-900 */
+          --scrollbar-thumb-color: #475569; /* Tailwind slate-600 */
+        }
+
         body {
             font-family: 'Rubik', 'Assistant', sans-serif;
             scroll-behavior: smooth;
@@ -26,14 +36,14 @@
         }
 
         ::-webkit-scrollbar-track {
-            background: #f1f5f9; /* Tailwind slate-100 */
+            background: var(--scrollbar-track-color);
             border-radius: 10px;
         }
 
         ::-webkit-scrollbar-thumb {
-            background-color: #94a3b8; /* Tailwind slate-400 */
+            background-color: var(--scrollbar-thumb-color);
             border-radius: 10px;
-            border: 3px solid #f1f5f9; /* Tailwind slate-100 */
+            border: 3px solid var(--scrollbar-track-color);
         }
 
             ::-webkit-scrollbar-thumb:hover {
@@ -41,15 +51,21 @@
             }
 
         html.dark ::-webkit-scrollbar-track {
-            background: #0f172a; /* Tailwind slate-900 */
+            background: var(--scrollbar-track-color);
         }
 
         html.dark ::-webkit-scrollbar-thumb {
-            background-color: #475569; /* Tailwind slate-600 */
-            border-color: #0f172a; /* Tailwind slate-900 */
+            background-color: var(--scrollbar-thumb-color);
+            border-color: var(--scrollbar-track-color);
         }
+
+        /* For light mode scrollbar corner */
+        ::-webkit-scrollbar-corner {
+          background-color: var(--scrollbar-track-color);
+        }
+
 html.dark ::-webkit-scrollbar-corner {
-    background: #0f172a;   /* צבע כהה תואם track */
+    background: var(--scrollbar-track-color);   /* צבע כהה תואם track */
 }
             html.dark ::-webkit-scrollbar-thumb:hover {
                 background-color: #334155; /* Tailwind slate-700 */


### PR DESCRIPTION
The scrollbar previously showed white edges at the top and bottom, particularly noticeable in dark mode, due to unstyled or incorrectly styled scrollbar corner and track elements.

This commit introduces CSS variables for scrollbar track and thumb colors, supporting both light and dark themes.

Changes:
- Defined `--scrollbar-track-color` and `--scrollbar-thumb-color` CSS variables in `:root` (for light theme) and `html.dark` (for dark theme) within the inline styles in `index.html`.
- Updated all `::-webkit-scrollbar-track`, `::-webkit-scrollbar-thumb`, and `::-webkit-scrollbar-corner` rules to use these CSS variables.
- Ensured `::-webkit-scrollbar-corner` has a defined background color for both light and dark modes, matching the track color.

This resolves the white edge issue and makes the scrollbar styling more consistent and maintainable.